### PR TITLE
refactor: standardize ui across pages and components

### DIFF
--- a/src/components/dialog/dialog.vue
+++ b/src/components/dialog/dialog.vue
@@ -66,7 +66,7 @@ const handleSubmit = () => {
       @interact-outside="(e) => e.preventDefault()"
     >
       <DialogHeader>
-        <DialogTitle>{{ defaultTitle }}</DialogTitle>
+        <DialogTitle class="capitalize">{{ defaultTitle }}</DialogTitle>
         <DialogDescription>
           {{ defaultDescription }}
         </DialogDescription>

--- a/src/components/layouts/superuser.vue
+++ b/src/components/layouts/superuser.vue
@@ -71,7 +71,7 @@ const items: MenuItem[] = [
     icon: Files,
     children: [
       {
-        title: 'File Ticket',
+        title: 'Create Ticket',
         url: '/su/tickets/create',
         icon: FilePlus,
       },
@@ -207,7 +207,7 @@ const footer: FooterItem[] = [
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
-      <SidebarFooter>
+      <SidebarFooter class="border-t">
         <SidebarMenu>
           <SidebarMenuItem>
             <DropdownMenu>

--- a/src/components/ui/card/CardTitle.vue
+++ b/src/components/ui/card/CardTitle.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
 </script>
 
 <template>
-  <h3 data-slot="card-title" :class="cn('leading-none font-semibold', props.class)">
+  <h3 data-slot="card-title" :class="cn('leading-none font-medium', props.class)">
     <slot />
   </h3>
 </template>

--- a/src/modules/dashboard/pages/superuser.vue
+++ b/src/modules/dashboard/pages/superuser.vue
@@ -110,19 +110,19 @@ type PieData = (typeof pie)[number];
 const pieConfig = {
   new: {
     label: 'New',
-    color: 'var(--chart-1)',
+    color: 'var(--color-purple-400)',
   },
   inProgress: {
     label: 'In Progress',
-    color: 'var(--chart-2)',
+    color: 'var(--color-blue-400)',
   },
   resolved: {
     label: 'Resolved',
-    color: 'var(--chart-3)',
+    color: 'var(--color-green-300)',
   },
   closed: {
     label: 'Closed',
-    color: 'var(--chart-4)',
+    color: 'var(--color-gray-400)',
   },
 } satisfies ChartConfig;
 
@@ -173,7 +173,7 @@ const getTrend = (percentage: number) => {
 <template>
   <div class="flex flex-col gap-4 px-4 py-4 md:px-6">
     <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-      <h2 class="hidden text-xl font-bold sm:block">Overview</h2>
+      <h3 class="hidden text-xl font-medium sm:block">Overview</h3>
       <div class="flex flex-col gap-2 sm:flex-row sm:justify-end">
         <div
           class="text-muted-foreground flex items-center justify-center gap-2 rounded-sm border p-2 text-sm"
@@ -183,7 +183,7 @@ const getTrend = (percentage: number) => {
         </div>
         <Button class="w-full sm:w-auto">
           <Download class="mr-2 size-4" />
-          Download Report
+          Download
         </Button>
       </div>
     </div>

--- a/src/modules/departments/columns.ts
+++ b/src/modules/departments/columns.ts
@@ -10,7 +10,7 @@ export const columns: ColumnDef<Department>[] = [
   {
     accessorKey: 'name',
     header: ({ column }) => h(ColumnHeader, { column }, () => 'Name'),
-    cell: ({ row }) => h('div', { class: 'text-left' }, row.getValue('name')),
+    cell: ({ row }) => row.getValue('name'),
     enableSorting: true,
   },
   {

--- a/src/modules/departments/pages/index.vue
+++ b/src/modules/departments/pages/index.vue
@@ -80,13 +80,13 @@ watch(isDialogOpen, (open) => {
       <FormDialog
         v-model:open="isDialogOpen"
         name="department"
-        title="Create new department"
+        title="Create Department"
         description="Create a new department by providing a descriptive name. Click create when you are done."
         submit-text="Create"
         @submit="onSubmit"
       >
         <template #trigger>
-          <Button type="button"><Plus />Create New</Button>
+          <Button type="button"><Plus />Create</Button>
         </template>
 
         <template #content>

--- a/src/modules/departments/pages/view.vue
+++ b/src/modules/departments/pages/view.vue
@@ -54,7 +54,7 @@ watch(isDialogOpen, (open) => {
 <template>
   <div class="w-full p-5">
     <Card>
-      <CardHeader>
+      <CardHeader class="flex items-center justify-between">
         <CardTitle>Team Banana</CardTitle>
         <CardAction>
           <FormDialog v-model:open="isDialogOpen" name="department" @submit="onSubmit">

--- a/src/modules/faqs/columns.ts
+++ b/src/modules/faqs/columns.ts
@@ -13,7 +13,7 @@ export const columns: ColumnDef<Faq>[] = [
   {
     accessorKey: 'title',
     header: ({ column }) => h(ColumnHeader, { column }, () => 'Title'),
-    cell: ({ row }) => h('div', { class: 'text-left' }, row.getValue('title')),
+    cell: ({ row }) => row.getValue('title'),
     enableSorting: true,
   },
   {
@@ -27,7 +27,11 @@ export const columns: ColumnDef<Faq>[] = [
     header: ({ column }) => h(ColumnHeader, { column }, () => 'Updated At'),
     cell: ({ row }) => {
       const date = row.getValue<Date>('updated_at');
-      return h('div', { class: 'text-left tabular-nums' }, formatDate(date));
+      return h(
+        'div',
+        { class: 'text-left tabular-nums' },
+        formatDate(date, { month: 'short', hour: undefined, minute: undefined, hour12: undefined })
+      );
     },
     enableSorting: false,
   },

--- a/src/modules/faqs/pages/create.vue
+++ b/src/modules/faqs/pages/create.vue
@@ -54,7 +54,7 @@ const onSubmit = handleSubmit((data) => {
   <form class="w-full p-5" @submit="onSubmit">
     <FieldGroup>
       <FieldSet>
-        <FieldLegend>Create a FAQ</FieldLegend>
+        <FieldLegend>Create FAQ</FieldLegend>
         <FieldDescription> Provide the details below to create a new FAQ. </FieldDescription>
 
         <VeeField v-slot="{ componentField }" name="title">

--- a/src/modules/faqs/pages/view.vue
+++ b/src/modules/faqs/pages/view.vue
@@ -68,7 +68,7 @@ watch(isDialogOpen, (open) => {
       <CardHeader>
         <CardTitle class="flex flex-row items-center justify-between gap-2">
           <div class="flex flex-col gap-y-1">
-            <span class="leading-relaxed"> {{ faq.title }}</span>
+            <span class="text-xl leading-relaxed"> {{ faq.title }}</span>
             <div class="text-muted-foreground flex items-center gap-1 text-sm">
               <Eye class="size-4" />
               232 views
@@ -107,7 +107,7 @@ watch(isDialogOpen, (open) => {
         <div class="flex items-center gap-2">
           <UserAvatar :name="faq.author" :subtitle="formatDate(faq.updated_at)" variant="md" />
         </div>
-        <p class="leading-relaxed">
+        <p class="text-sm leading-relaxed">
           {{ faq.content }}
         </p>
       </CardContent>

--- a/src/modules/tickets/columns.ts
+++ b/src/modules/tickets/columns.ts
@@ -23,26 +23,21 @@ export const columns: ColumnDef<Ticket>[] = [
       const date = row.getValue<Date>('date');
       return h(
         'div',
-        { class: 'text-left tabular-nums' },
-
-        formatDate(new Date(date), {
-          year: 'numeric',
-          month: 'short',
-          day: '2-digit',
-        })
+        { class: 'tabular-nums' },
+        formatDate(date, { month: 'short', hour: undefined, minute: undefined, hour12: undefined })
       );
     },
   },
   {
     accessorKey: 'title',
     header: ({ column }) => h(ColumnHeader, { column }, () => 'Title'),
-    cell: ({ row }) => h('div', { class: 'text-left' }, row.getValue('title')),
+    cell: ({ row }) => row.getValue('title'),
     enableSorting: false,
   },
   {
     accessorKey: 'department',
     header: ({ column }) => h(ColumnHeader, { column }, () => 'Department'),
-    cell: ({ row }) => h('div', { class: 'text-left' }, row.getValue('department')),
+    cell: ({ row }) => row.getValue('department'),
     enableSorting: false,
   },
   {

--- a/src/modules/tickets/components/activity-section.vue
+++ b/src/modules/tickets/components/activity-section.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Circle } from 'lucide-vue-next';
 
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 import { formatDate } from '@/lib/utils';
 
@@ -15,7 +15,7 @@ defineProps<{
 <template>
   <Card class="min-h-100">
     <CardHeader>
-      <h3 class="text-sm font-semibold">Activity</h3>
+      <CardTitle>Activity </CardTitle>
     </CardHeader>
     <CardContent class="max-h-125 space-y-3 overflow-y-auto">
       <div

--- a/src/modules/tickets/components/comments-section.vue
+++ b/src/modules/tickets/components/comments-section.vue
@@ -79,7 +79,7 @@ const hasMore = computed(() => props.comments.length > limit);
 
 <template>
   <div>
-    <h3 class="text-sm font-semibold">Discussion</h3>
+    <h3 class="font-medium">Discussion</h3>
     <form class="space-y-2" @submit="onSubmit">
       <VeeField v-slot="{ componentField }" name="comment">
         <Textarea v-bind="componentField" placeholder="Comment as Juan" class="w-full" />

--- a/src/modules/tickets/components/details-section.vue
+++ b/src/modules/tickets/components/details-section.vue
@@ -31,8 +31,8 @@ const emit = defineEmits<{
     class="space-y-2 rounded-lg border p-5 shadow-sm"
     @update:open="emit('update:open', $event)"
   >
-    <div class="flex items-center justify-between">
-      <h3 class="text-sm font-semibold">Details</h3>
+    <div class="mb-6 flex items-center justify-between">
+      <h3 class="font-medium">Details</h3>
       <CollapsibleTrigger as-child>
         <Button variant="ghost" size="icon" class="size-8">
           <ChevronDown

--- a/src/modules/tickets/pages/create.vue
+++ b/src/modules/tickets/pages/create.vue
@@ -190,7 +190,7 @@ const onSubmit = handleSubmit((data) => {
   <form class="w-full p-5" @submit="onSubmit">
     <FieldGroup>
       <FieldSet>
-        <FieldLegend>File a Ticket</FieldLegend>
+        <FieldLegend>Create Ticket</FieldLegend>
         <FieldDescription>
           Provide the details below and we'll get your issue resolved quickly.
         </FieldDescription>
@@ -353,7 +353,7 @@ const onSubmit = handleSubmit((data) => {
 
         <div class="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
           <Button type="button" variant="secondary" @click="handleCancel"> Cancel </Button>
-          <Button type="submit">File Ticket</Button>
+          <Button type="submit">Create</Button>
         </div>
       </FieldSet>
     </FieldGroup>

--- a/src/modules/tickets/pages/view.vue
+++ b/src/modules/tickets/pages/view.vue
@@ -179,9 +179,8 @@ const description = `I'm unable to log into my account and need help regaining a
     <Card>
       <CardHeader>
         <div class="space-y-1">
-          <CardTitle class="flex flex-row items-center justify-between gap-2">
-            <span class="leading-relaxed"> {{ ticket.title }}</span>
-
+          <CardTitle class="flex items-center justify-between gap-2 text-xl">
+            {{ ticket.title }}
             <FormDialog v-model:open="isDialogOpen" name="ticket" @submit="onSubmit">
               <template #content>
                 <FieldGroup>
@@ -270,8 +269,8 @@ const description = `I'm unable to log into my account and need help regaining a
       </CardHeader>
       <CardContent class="mt-1 space-y-7">
         <div class="space-y-1">
-          <h3 class="mb-2 text-sm font-semibold">Description</h3>
-          <p class="leading-relaxed">{{ description }}</p>
+          <h3 class="font-medium">Description</h3>
+          <p class="text-sm leading-relaxed">{{ description }}</p>
         </div>
         <ItemGroup v-if="attachments.length" class="gap-y-2">
           <AttachmentItem v-for="(attachment, index) in attachments" :key="index" :attachment />

--- a/src/modules/users/columns.ts
+++ b/src/modules/users/columns.ts
@@ -17,19 +17,19 @@ export const columns: ColumnDef<User>[] = [
   {
     accessorKey: 'email',
     header: ({ column }) => h(ColumnHeader, { column }, () => 'Email Address'),
-    cell: ({ row }) => h('div', { class: 'text-left' }, row.getValue('email')),
+    cell: ({ row }) => row.getValue('email'),
     enableSorting: false,
   },
   {
     accessorKey: 'department',
     header: ({ column }) => h(ColumnHeader, { column }, () => 'Department'),
-    cell: ({ row }) => h('div', { class: 'text-left' }, row.getValue('department')),
+    cell: ({ row }) => row.getValue('department'),
     enableSorting: false,
   },
   {
     accessorKey: 'role',
     header: ({ column }) => h(ColumnHeader, { column }, () => 'Role'),
-    cell: ({ row }) => h('div', { class: 'text-left' }, row.getValue('role')),
+    cell: ({ row }) => row.getValue('role'),
     enableSorting: false,
   },
   {

--- a/src/router.ts
+++ b/src/router.ts
@@ -27,7 +27,7 @@ const routes = [
         children: [
           {
             path: 'create',
-            name: 'File Ticket',
+            name: 'Create Ticket',
             component: () => import('@/modules/tickets/pages/create.vue'),
           },
           {


### PR DESCRIPTION
closes #33 

### summary of changes

`form pages`
- use `<h3 />` for page titles
- standardize title and description texts
- use single-word labels for all `<Button /> `labels

`column.ts `
- remove excess div wrapper and `text-left` class 
- add `formatDate opts` to display short month, date, and year only for tables

`dashboard.vue `
- change chart colors to `color-400` and `color-300` to match the colors used in `<StatusBadge />`

`CardTitle.vue`
- reduce font-weight from `font-semibold` to `font-medium`